### PR TITLE
Dont use query params in the redirect URI

### DIFF
--- a/lib/omniauth/strategies/canvas.rb
+++ b/lib/omniauth/strategies/canvas.rb
@@ -41,7 +41,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get("/api/v1/users/#{access_token['user']['id']}/profile").parsed
       end
-
+      
+      def query_string
+        ''
+      end
     end
   end
 end


### PR DESCRIPTION
As of https://github.com/instructure/canvas-lms/commit/49ee1a33aa5cf0c607868f7b7ad6a038b5d5073e
Canvas does strict checking of redirect URIs
